### PR TITLE
feat: add a method for listing popular categories/hashtags

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ const api = new TikTokAPI(params, { signURL });
 * [.unlikePost(id)](#unlikepostid)
 * [.listComments(params)](#listcommentsparams)
 * [.postComment(postId, text, [tags])](#postcommentpostid-text-tags)
+* [.listCategories(params)](#listcategoriesparams)
 
 #### .loginWithEmail(email, password)
 
@@ -243,6 +244,25 @@ api.postComment('<post_id>', 'first!')
 ```
 
 See the [comment types](src/types/comment.d.ts) for the response data.
+
+#### .listCategories(params)
+
+Lists popular categories/hashtags.
+
+```javascript
+api.listCategories({
+  count: 10,
+  cursor: 0,
+})
+  .then(res => console.log(res.data.category_list))
+  .catch(console.log);
+
+// Outputs:
+// [{ { challenge_info: { cha_name: 'posechallenge', cid: '123' }, desc: 'Trending Hashtag' }, ...]
+
+```
+
+See the [category types](src/types/category.d.ts) for the complete request/response objects.
 
 ## Resources
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import {
   FollowResponse,
   LikePostRequest,
   LikePostResponse,
+  ListCategoriesRequest,
+  ListCategoriesResponse,
   ListCommentsRequest,
   ListCommentsResponse,
   ListFollowersRequest,
@@ -245,6 +247,16 @@ export default class TikTokAPI {
         },
       },
     )
+
+  /**
+   * Lists popular categories/hashtags.
+   *
+   * @param params
+   */
+  listCategories = (params: ListCategoriesRequest = { count: 10, cursor: 0 }) =>
+    this.request.get<ListCategoriesResponse | BaseResponseData>('aweme/v1/category/list/', {
+      params: withDefaultListParams(params),
+    })
 
   /**
    * Transform using JSONBig to store big numbers accurately (e.g. user IDs) as strings.

--- a/src/types/category.d.ts
+++ b/src/types/category.d.ts
@@ -1,0 +1,54 @@
+import { Post } from './post';
+import { CommonUserDetails } from './user';
+import {
+  CountOffsetParams,
+  ListRequestParams,
+  ListResponseData
+} from './request';
+
+export interface ListCategoriesRequest extends ListRequestParams, CountOffsetParams {}
+
+export interface ListCategoriesResponse extends ListResponseData, CountOffsetParams {
+  /** A list of categories */
+  category_list: Category[];
+}
+
+export interface Category {
+  /** A list of posts in the category */
+  aweme_list: Post[];
+
+  /** The type of category - 0 for hashtag? */
+  category_type: number;
+
+  /** Information about the category */
+  challenge_info: ChallengeInfo;
+
+  /** A description of the category type, e.g. "Trending Hashtag" */
+  desc: string;
+}
+
+export interface ChallengeInfo {
+  /** The user who created the challenge, or an empty object */
+  author: CommonUserDetails | {};
+
+  /** The name of the challenge */
+  cha_name: string;
+
+  /** The ID of the challenge */
+  cid: string;
+
+  /** A description of the challenge */
+  desc: string;
+
+  /** ??? */
+  is_pgcshow: boolean;
+
+  /** An in-app link to the challenge */
+  schema: string;
+
+  /** The type of challenge - 0 for hashtag? */
+  type: number;
+
+  /** The number of users who have uploaded a video for the challenge */
+  user_count: number;
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,4 +1,5 @@
 export * from './api';
+export * from './category';
 export * from './comment';
 export * from './follow';
 export * from './follower';

--- a/src/types/request.d.ts
+++ b/src/types/request.d.ts
@@ -175,10 +175,10 @@ export interface CountOffsetParams {
 export interface BaseResponseData {
   extra: {
     /** ??? */
-    fatal_item_ids: number[];
+    fatal_item_ids?: number[];
 
     /** A log ID for this request */
-    logid: string;
+    logid?: string;
 
     /** The current timestamp in milliseconds */
     now: number;

--- a/test/category.spec.ts
+++ b/test/category.spec.ts
@@ -1,0 +1,48 @@
+import MockAdapter from 'axios-mock-adapter';
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import TikTokAPI, { ListCategoriesResponse } from '../src';
+import {
+  loadTestData,
+  mockConfig,
+  mockParams,
+} from './util';
+
+describe('#listCategories()', () => {
+  it('a successful response should match the interface', async () => {
+    const api = new TikTokAPI(mockParams, mockConfig);
+    const mock = new MockAdapter(api.request);
+    mock
+      .onGet(new RegExp('aweme/v1/category/list/\?.*'))
+      .reply(200, loadTestData('listCategories.json'), {});
+
+    const res = await api.listCategories();
+    const expected: ListCategoriesResponse = {
+      extra: {
+        now: 1000000000000,
+      },
+      category_list: [
+        {
+          aweme_list: [],
+          category_type: 0,
+          challenge_info: {
+            author: {},
+            cha_name: 'examplechallenge',
+            cid: '9999999',
+            desc: 'example',
+            is_pgcshow: false,
+            schema: '',
+            type: 0,
+            user_count: 100000,
+          },
+          desc: 'Trending Hashtag',
+        },
+      ],
+      cursor: 10,
+      has_more: 1,
+      status_code: 0,
+    };
+    assert.deepStrictEqual(res.data, expected);
+  });
+});

--- a/test/testdata/listCategories.json
+++ b/test/testdata/listCategories.json
@@ -1,0 +1,23 @@
+{
+  "extra": {
+    "now": 1000000000000
+  },
+  "category_list": [{
+    "aweme_list": [],
+    "category_type": 0,
+    "challenge_info": {
+      "author": {},
+      "cha_name": "examplechallenge",
+      "cid": "9999999",
+      "desc": "example",
+      "is_pgcshow": false,
+      "schema": "",
+      "type": 0,
+      "user_count": 100000
+    },
+    "desc": "Trending Hashtag"
+  }],
+  "cursor": 10,
+  "has_more": 1,
+  "status_code": 0
+}


### PR DESCRIPTION
Closes #22 

I've also made some of the `extra` response object information optional as some requests no longer include it.