### PR TITLE
fix: update package name in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "musically-api",
+  "name": "tiktok-api",
   "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
This was missed when renaming the package from `musically-api` to `tiktok-api`. 